### PR TITLE
Clean up connected wallet display

### DIFF
--- a/frontend/src/components/ConnectedAccount/index.module.css
+++ b/frontend/src/components/ConnectedAccount/index.module.css
@@ -3,7 +3,6 @@
   justify-items: center;
   align-items: center;
   gap: 1rem;
-  min-width: 350px;
   max-height: 48px;
   border-radius: 12px;
   background: var(--white);
@@ -17,14 +16,13 @@
   flex-wrap: nowrap;
   justify-content: space-between;
   align-items: center;
-  width: 270px;
   color: var(--navy-blue);
   text-align: end;
   margin-bottom: 0;
+  gap: 16px;
 }
 
 .connectedAccountAddress {
-  flex: 1 1 60%;
   font-family: monospace;
   text-decoration: none;
   font-size: 22px;
@@ -35,8 +33,6 @@
 }
 
 .network {
-  flex: 0 0 40%;
-  overflow: hidden;
   max-height: 28px;
   font-size: 20px;
   font-weight: 400;
@@ -44,6 +40,9 @@
   letter-spacing: 0;
   text-align: left;
   text-transform: capitalize;
+  overflow: hidden;
+  text-wrap: nowrap;
+  width: 80px;
 }
 
 @media screen and (max-width: 1000px) {

--- a/frontend/src/components/ConnectedAccount/index.tsx
+++ b/frontend/src/components/ConnectedAccount/index.tsx
@@ -5,6 +5,7 @@ import { StringUtils } from '../../utils/string.utils'
 import classes from './index.module.css'
 import { useAppState } from '../../hooks/useAppState'
 import { AddressShower } from '../Addresses'
+import { motion } from 'framer-motion'
 
 interface Props {
   className?: string
@@ -21,7 +22,6 @@ export const ConnectedAccount: FC<Props> = ({ className, address, chainName }) =
   } = useAppState()
 
   const url = explorerBaseUrl ? StringUtils.getAccountUrl(explorerBaseUrl, address) : undefined
-  const networkName = StringUtils.getNetworkFriendlyName(chainName)
 
   return (
     <a
@@ -33,7 +33,13 @@ export const ConnectedAccount: FC<Props> = ({ className, address, chainName }) =
       <JazzIcon size={isDesktopScreen ? 30 : 20} address={address} />
       {isDesktopScreen && (
         <p className={classes.connectedAccountDetails}>
-          <span className={classes.network}>{networkName}</span>
+          <motion.span
+            className={classes.network}
+            whileHover={{ width: 'auto' }}
+            transition={{ ease: 'easeInOut' }}
+          >
+            {chainName}
+          </motion.span>
           <AddressShower address={address} className={classes.connectedAccountAddress} />
         </p>
       )}

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -2,12 +2,6 @@
 import { ExtendedPoll } from '../types'
 import { randomchoice } from '@oasisprotocol/blockvote-contracts'
 
-export const NETWORK_NAMES: Record<string, string> = {
-  'Oasis Sapphire': 'Sapphire',
-  'Oasis Sapphire Testnet': 'Sapphire Testnet',
-  'Sapphire Localnet': 'Sapphire Localnet',
-}
-
 export const METAMASK_HOME_PAGE_URL = 'https://metamask.io/'
 // export const GITHUB_REPOSITORY_URL = 'https://github.com/oasisprotocol/dapp-votee/'
 

--- a/frontend/src/utils/string.utils.ts
+++ b/frontend/src/utils/string.utils.ts
@@ -1,5 +1,3 @@
-import { NETWORK_NAMES } from '../constants/config'
-
 const truncateRegex = /^(0x[a-zA-Z0-9]{4})[a-zA-Z0-9]+([a-zA-Z0-9]{4})$/
 
 export abstract class StringUtils {
@@ -20,10 +18,6 @@ export abstract class StringUtils {
       .map(className => (className ? [className] : []))
       .flat()
       .join(' ')
-  }
-
-  static getNetworkFriendlyName = (chainName: string) => {
-    return NETWORK_NAMES[chainName] ?? 'Unknown network'
   }
 
   static truncate = (s: string, sliceIndex = 200) => {


### PR DESCRIPTION
- Remove hand-picked network names
- Use network name from chain_info
- Show the whole name when hovering