### PR TITLE
Allow HTML content in reasons for decisions

### DIFF
--- a/frontend/src/components/InputFields/TextArrayInput.tsx
+++ b/frontend/src/components/InputFields/TextArrayInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react'
+import React, { FC, ReactNode, useCallback } from 'react'
 import { TextArrayControls } from './useTextArrayField'
 import classes from './index.module.css'
 import { StringUtils } from '../../utils/string.utils'
@@ -13,7 +13,7 @@ import { MotionDiv } from '../Animations'
 import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 
 const TrashIcon: FC<{
-  label: string
+  label: ReactNode
   remove: () => void
   enabled?: boolean
 }> = ({ label, remove, enabled }) => {

--- a/frontend/src/components/InputFields/useInputField.ts
+++ b/frontend/src/components/InputFields/useInputField.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 import {
   AllProblems,
   ValidatorControls,
@@ -159,7 +159,7 @@ export type InputFieldControls<DataType> = Pick<
   type: string
   visible: boolean
   enabled: boolean
-  whyDisabled?: string
+  whyDisabled?: ReactNode
   containerClassName?: string
   value: DataType
   setValue: (value: DataType) => void

--- a/frontend/src/components/InputFields/util.ts
+++ b/frontend/src/components/InputFields/util.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 export type ProblemLevel = 'warning' | 'error'
 
 export type Problem = {
@@ -136,17 +138,17 @@ export const findDuplicates = (
 }
 
 type SimpleDecision = boolean
-type FullDecision = { verdict: boolean; reason?: string }
+type FullDecision = { verdict: boolean; reason?: ReactNode }
 export type Decision = SimpleDecision | FullDecision
 
-type FullPositiveDecision = { verdict: boolean; reason?: string }
-type FullNegativeDecision = { verdict: boolean; reason: string }
+type FullPositiveDecision = { verdict: boolean; reason?: ReactNode }
+type FullNegativeDecision = { verdict: boolean; reason: ReactNode }
 export type DecisionWithReason = true | FullPositiveDecision | FullNegativeDecision
 
-export const allow = (reason?: string): Decision => ({ verdict: true, reason })
+export const allow = (reason?: ReactNode): Decision => ({ verdict: true, reason })
 
-export const deny = (reason?: string): Decision => ({ verdict: false, reason })
-export const denyWithReason = (reason: string): FullNegativeDecision => ({ verdict: false, reason })
+export const deny = (reason?: ReactNode): Decision => ({ verdict: false, reason })
+export const denyWithReason = (reason: ReactNode): FullNegativeDecision => ({ verdict: false, reason })
 
 export const expandDecision = (decision: Decision): FullDecision =>
   typeof decision === 'boolean' ? { verdict: decision } : decision
@@ -179,17 +181,17 @@ export const andDecisions = (a: Decision, b: Decision): Decision => {
 export const getVerdict = (decision: Decision | undefined, defaultVerdict: boolean): boolean =>
   decision === undefined ? defaultVerdict : typeof decision === 'boolean' ? decision : decision.verdict
 
-export const getReason = (decision: Decision | undefined): string | undefined =>
+export const getReason = (decision: Decision | undefined): ReactNode | undefined =>
   decision === undefined ? undefined : typeof decision === 'boolean' ? undefined : decision.reason
 
-export const getReasonForDenial = (decision: Decision | undefined): string | undefined =>
+export const getReasonForDenial = (decision: Decision | undefined): ReactNode | undefined =>
   decision === undefined
     ? undefined
     : typeof decision === 'boolean' || decision.verdict
       ? undefined
       : decision.reason
 
-export const getReasonForAllowing = (decision: Decision | undefined): string | undefined =>
+export const getReasonForAllowing = (decision: Decision | undefined): ReactNode | undefined =>
   decision === undefined
     ? undefined
     : typeof decision === 'boolean' || !decision.verdict


### PR DESCRIPTION
Up to now, in utilities dealing with Decisions,
the "reason" (if given) always had to be a string.

Now we extend it to ReactNode, so we can now provide any HTML content as reason.

(This is useful so that we can embed links in reasons, for example.)