### PR TITLE
Refactor gasless/gas required icon

### DIFF
--- a/frontend/src/components/PollCard/index.tsx
+++ b/frontend/src/components/PollCard/index.tsx
@@ -2,8 +2,7 @@ import { isPollActive, Proposal } from '../../types'
 import { FC, MouseEventHandler, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import classes from './index.module.css'
-import { GasRequiredIcon } from '../icons/GasRequiredIcon'
-import { NoGasRequiredIcon } from '../icons/NoGasRequiredIcon'
+import { showGaslessPossible } from '../icons/GasRequiredIcon'
 import { SpinnerIcon } from '../icons/SpinnerIcon'
 import { HourGlassIcon } from '../icons/HourGlassIcon'
 import { StringUtils } from '../../utils/string.utils'
@@ -58,17 +57,6 @@ const PollStatusIndicator: FC<{ active: boolean; isPastDue: boolean }> = ({ acti
     </MaybeWithTooltip>
   )
 }
-
-const GaslessStatusIndicator: FC<{ possible: boolean | undefined }> = ({ possible }) =>
-  possible === undefined ? (
-    <SpinnerIcon size={'medium'} spinning />
-  ) : possible ? (
-    designDecisions.hideGaslessIndicator ? undefined : (
-      <NoGasRequiredIcon />
-    )
-  ) : (
-    <GasRequiredIcon />
-  )
 
 export const PollCard: FC<{
   column: Column
@@ -213,7 +201,7 @@ export const PollCard: FC<{
               <div dangerouslySetInnerHTML={{ __html: highlightedDescription }} />
               <div className={classes.pollCardBottom}>
                 <PollStatusIndicator active={active} isPastDue={isPastDue} />
-                {dashboard.showGasless && <GaslessStatusIndicator possible={gaslessPossible} />}
+                {dashboard.showGasless ? showGaslessPossible(gaslessPossible) : undefined}
               </div>
             </div>
           </Link>

--- a/frontend/src/components/icons/GasRequiredIcon.tsx
+++ b/frontend/src/components/icons/GasRequiredIcon.tsx
@@ -3,10 +3,11 @@ import { MaybeWithTooltip } from '../Tooltip/MaybeWithTooltip'
 import { designDecisions, faucetUrl } from '../../constants/config'
 import { NoGasRequiredIcon } from './NoGasRequiredIcon'
 
-export const GasRequiredIcon: FC = () => {
+const GasRequiredIcon: FC<{ linkAllowed: boolean }> = ({ linkAllowed }) => {
+  const useLink = !!faucetUrl && linkAllowed
   const icon = (
     <MaybeWithTooltip
-      overlay={`Voting requires paying for some gas.${faucetUrl ? ' Click here to get come' : ''}`}
+      overlay={`Voting requires paying for some gas.${useLink ? ' Click here to get come' : ''}`}
     >
       <svg width="17" height="19" viewBox="0 0 17 19" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
@@ -17,7 +18,7 @@ export const GasRequiredIcon: FC = () => {
     </MaybeWithTooltip>
   )
 
-  return faucetUrl ? (
+  return useLink ? (
     <a href={faucetUrl} target={'_blank'}>
       {icon}
     </a>
@@ -26,11 +27,11 @@ export const GasRequiredIcon: FC = () => {
   )
 }
 
-export const showGaslessPossible = (gaslessPossible: boolean | undefined) =>
+export const showGaslessPossible = (gaslessPossible: boolean | undefined, linkAllowed = false) =>
   gaslessPossible ? (
     designDecisions.hideGaslessIndicator ? undefined : (
       <NoGasRequiredIcon />
     )
   ) : (
-    <GasRequiredIcon />
+    <GasRequiredIcon linkAllowed={linkAllowed} />
   )

--- a/frontend/src/pages/PollPage/hook.ts
+++ b/frontend/src/pages/PollPage/hook.ts
@@ -161,7 +161,7 @@ export const usePollData = (pollId: string) => {
     name: 'gaslessIndicator',
     value: gaslessPossible,
     visible: getVerdict(permissions.canVote, false),
-    renderer: showGaslessPossible,
+    renderer: possible => showGaslessPossible(possible, true),
   })
 
   const voteAction = useAction({


### PR DESCRIPTION
- Consistently use the helper function to select the correct icon
- Make the faucet linking feature optional (since we don't want this on poll cards)