### PR TITLE
Extend network switch exception recognition

### DIFF
--- a/frontend/src/providers/EthereumProvider.tsx
+++ b/frontend/src/providers/EthereumProvider.tsx
@@ -150,7 +150,7 @@ export const EthereumContextProvider: FC<PropsWithChildren> = ({ children }) => 
         ])
         l_network = ConfiguredNetwork
       } catch (e: any) {
-        if ((e as any).error?.code === 4902) {
+        if ((e as any).error?.code === 4902 || (e as any).error?.data?.originalError?.code === 4903) {
           await addNetwork(ConfiguredNetwork)
         } else {
           throw e


### PR DESCRIPTION
When trying to switch wallet network in Metamask's browser, we don't get an error with code 4909, but a "could not coalesce error" message, with and embedded error, which has code 4909.

Attempt to recognize that, too.