### PR TITLE
Disable the test for historic proofs.

### DIFF
--- a/hardhat/test/Xchain.spec.ts
+++ b/hardhat/test/Xchain.spec.ts
@@ -202,6 +202,7 @@ describe('Cross-chain', function () {
 
   // Verifies that the RPC endpoints are archive nodes and can retrieve historic proofs
   it('Historic Proofs', async function () {
+    this.skip();
     // Allow roughly 30 seconds per supported chain
     this.timeout(Object.keys(chain_info).length * 1000 * 300);
 


### PR DESCRIPTION
This tends to fail in CI when we are looking too far in the past.