### PR TITLE
Small input form improvements

### DIFF
--- a/frontend/src/components/InputFields/useInputField.ts
+++ b/frontend/src/components/InputFields/useInputField.ts
@@ -421,8 +421,23 @@ export function useInputFieldInternal<DataType>(
     const oldLength = latestMessages.length
     latestMessages = latestMessages.filter(p => p.text !== message || p.type === 'info')
     setMessages(latestMessages)
-    if (messages.length !== oldLength) setIsValidated(false)
+    if (latestMessages.length !== oldLength) {
+      setIsValidated(false)
+    }
   }
+
+  useEffect(() => {
+    if (
+      !isValidated &&
+      !validationPending &&
+      !messages.length &&
+      !!validateOnChange &&
+      !enabled &&
+      !isEmpty(cleanValue)
+    ) {
+      void validate({ reason: 'change', isStillFresh: () => true })
+    }
+  }, [isValidated, validationPending, messages.length, validateOnChange, isEmpty(cleanValue), enabled])
 
   const clearMessagesAt = (location: string): void => {
     latestMessages = latestMessages.filter(p => p.location !== location)


### PR DESCRIPTION
- Add form field configuration option for enabling validation on hidden fields (they will be shown if there are errors)
- Make it so that manually acknowledging (and removing) error messages can re-trigger validation in some circumstances

The overall effect is that now there is support for allowing the user for manually re-trying a failed validation.