### PR TITLE
Set up vite to also generate 404.html

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import { defineConfig } from 'vite'
 import svgr from 'vite-plugin-svgr'
 import react from '@vitejs/plugin-react-swc'
@@ -13,6 +15,19 @@ export default defineConfig({
       useRecommendedBuildConfig: false,
       inlinePattern: ['assets/style-*.css'],
     }),
+    {
+      name: 'generate-404',
+      writeBundle() {
+        const indexPath = path.resolve(__dirname, 'dist/index.html')
+        const notFoundPath = path.resolve(__dirname, 'dist/404.html')
+        if (fs.existsSync(indexPath)) {
+          fs.copyFileSync(indexPath, notFoundPath)
+          console.log('Copied dist/index.html to dist/404.html')
+        } else {
+          console.warn('index.html not found in dist folder')
+        }
+      },
+    },
     visualizer(),
   ],
   base: './',


### PR DESCRIPTION
The idea is that we want to handle all paths
(including non-existent files) with the app routing, and don't want to see 404 page from GH pages at all.