### PR TITLE
Change how lido redirect works

### DIFF
--- a/frontend/public/lido
+++ b/frontend/public/lido
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-<meta http-equiv="refresh" content="0; url=https://vote-lido.oasis.io">
-</head>
-<body>
-</body>
-</html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,8 @@ import { setAnimationPolicy } from './components/Animations'
 import { allowedAnimations } from './constants/config'
 import 'rc-tooltip/assets/bootstrap_white.css'
 
+if (window.location.pathname.endsWith('/lido')) window.location.href = 'https://vote-lido.oasis.io'
+
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />)
 
 setAnimationPolicy({ id: 'allow', allow: allowedAnimations })


### PR DESCRIPTION
Since we are now handing all routing via the app router,
we can now do the redirect using the originally planned method.