### PR TITLE
Use browser router instead of hash router

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from 'react'
-import { createHashRouter, Outlet, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import { AppStateContextProvider } from './providers/AppStateProvider'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -16,7 +16,7 @@ import {
   VITE_APP_LIGHT_BG,
 } from './constants/config'
 
-const router = createHashRouter([
+const router = createBrowserRouter([
   {
     path: '/',
     element: <Outlet />,


### PR DESCRIPTION
This changes URLs to a more natural form, like:

- Create new: https://vote.oasis.io/#/create -> https://vote.oasis.io/create
- Poll: https://vote.oasis.io/#/bcjtzrf77a4oa -> https://vote.oasis.io/bcjtzrf77a4oa

(This was not possible earlier because of how deployment was set up, but since #148 all URLs will reach the router, so now we can do this.)